### PR TITLE
chore: add SECURITY.md and create GH release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,3 +117,11 @@ jobs:
           fi
           ./gradlew publishToSonatype ${cmd} --no-parallel -Pversion=$VERSION -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
 
+
+  # If we have a release version, also invoke the GH release job, bump versions, etc.
+  Create-GitHub-Release:
+    needs: [ Publish-Maven-Artefacts, Determine-Version ]
+    if: ${{ !endsWith(needs.Determine-Version.outputs.VERSION, '-SNAPSHOT') }}
+    uses: ./.github/workflows/release-cvf.yml
+    with:
+      cvf_version: ${{ needs.Determine-Version.outputs.VERSION }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Reporting a Vulnerability
+
+Please do **not** report security vulnerabilities through public GitHub issues.
+
+Please report vulnerabilities to this repository via **GitHub security advisories** instead.
+
+How? Inside affected repository → security tab
+
+for contributor:
+→ Report a vulnerability
+
+for committer:
+→ advisories → New draft security advisory
+
+In severe cases, you can also report a found vulnerability via mail or eclipse issue here: <https://www.eclipse.org/security/>
+
+See [Eclipse Foundation Vulnerability Reporting Policy](https://www.eclipse.org/projects/handbook/#vulnerability)


### PR DESCRIPTION
## What this PR changes/adds

Adds a `SECURITY.md` file and a workflow job to automatically create a GH release when a non-snapshot build was created.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at
the [contributing guidelines](https://github.com/eclipse-dataspacetck/cvf/blob/main/CONTRIBUTING.md#submit-a-pull-request)
and our [etiquette for pull requests](https://github.com/eclipse-dataspacetck/cvf/blob/main/pr_etiquette.md)._
