### PR TITLE
feat: Configurable HTTP Authorization header

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -4,7 +4,7 @@ maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.17.2, Apache-2.0 AN
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.17.2, Apache-2.0, approved, #13671
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jakarta-jsonp/2.17.2, Apache-2.0, approved, #14161
 maven/mavencentral/com.fasterxml.jackson/jackson-bom/2.17.2, Apache-2.0, approved, #14162
-maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, CC-BY-2.5, approved, #15220
+maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0 and CC-BY-2.5, approved, #15220
 maven/mavencentral/com.google.errorprone/error_prone_annotations/2.7.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/guava/31.0.1-jre, Apache-2.0, approved, clearlydefined

--- a/config/tck/sample.tck.properties
+++ b/config/tck/sample.tck.properties
@@ -3,6 +3,7 @@ dataspacetck.debug=true
 dataspacetck.dsp.local.connector=false
 dataspacetck.dsp.connector.agent.id=CONNECTOR_UNDER_TEST
 dataspacetck.dsp.connector.http.url=http://localhost:8282/api/v1/dsp/
+dataspacetck.dsp.connector.http.headers.authorization="{\"region\": \"any\", \"audience\": \"any\", \"clientId\":\"any\"}"
 dataspacetck.dsp.connector.negotiation.initiate.url=http://localhost:8687/tck/negotiations/requests
 dataspacetck.dsp.default.wait=10000000
 

--- a/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/DspSystemLauncher.java
+++ b/dsp/dsp-system/src/main/java/org/eclipse/dataspacetck/dsp/system/DspSystemLauncher.java
@@ -23,6 +23,7 @@ import org.eclipse.dataspacetck.core.spi.system.SystemConfiguration;
 import org.eclipse.dataspacetck.core.spi.system.SystemLauncher;
 import org.eclipse.dataspacetck.dsp.system.api.connector.Connector;
 import org.eclipse.dataspacetck.dsp.system.api.connector.Consumer;
+import org.eclipse.dataspacetck.dsp.system.api.http.HttpFunctions;
 import org.eclipse.dataspacetck.dsp.system.api.mock.ConsumerNegotiationMock;
 import org.eclipse.dataspacetck.dsp.system.api.mock.ProviderNegotiationMock;
 import org.eclipse.dataspacetck.dsp.system.api.pipeline.ConsumerNegotiationPipeline;
@@ -55,6 +56,7 @@ public class DspSystemLauncher implements SystemLauncher {
     private static final String LOCAL_CONNECTOR_CONFIG = TCK_PREFIX + ".dsp.local.connector";
     private static final String CONNECTOR_AGENT_ID_CONFIG = TCK_PREFIX + ".dsp.connector.agent.id";
     private static final String CONNECTOR_BASE_URL_CONFIG = TCK_PREFIX + ".dsp.connector.http.url";
+    private static final String CONNECTOR_BASE_AUTHORIZATION_HEADER_CONFIG = TCK_PREFIX + ".dsp.connector.http.header.authorization";
     private static final String CONNECTOR_INITIATE_URL_CONFIG = TCK_PREFIX + ".dsp.connector.negotiation.initiate.url";
     private static final String THREAD_POOL_CONFIG = TCK_PREFIX + ".dsp.thread.pool";
     private static final String DEFAULT_WAIT_CONFIG = TCK_PREFIX + ".dsp.default.wait";
@@ -64,6 +66,7 @@ public class DspSystemLauncher implements SystemLauncher {
     private ExecutorService executor;
     private String connectorUnderTestId = "ANONYMOUS";
     private String baseConnectorUrl;
+    private String baseAuthorizationHeader;
     private String connectorInitiateUrl;
     private boolean useLocalConnector;
     private long waitTime = DEFAULT_WAIT_SECONDS;
@@ -87,6 +90,10 @@ public class DspSystemLauncher implements SystemLauncher {
             baseConnectorUrl = configuration.getPropertyAsString(CONNECTOR_BASE_URL_CONFIG, null);
             if (baseConnectorUrl == null) {
                 throw new RuntimeException("Required configuration not set: " + CONNECTOR_BASE_URL_CONFIG);
+            }
+            baseAuthorizationHeader = configuration.getPropertyAsString(CONNECTOR_BASE_AUTHORIZATION_HEADER_CONFIG, null);
+            if (baseAuthorizationHeader != null) {
+                HttpFunctions.registerAuthorizationInterceptor(baseAuthorizationHeader);
             }
             connectorInitiateUrl = configuration.getPropertyAsString(CONNECTOR_INITIATE_URL_CONFIG, null);
             if (connectorInitiateUrl == null) {


### PR DESCRIPTION
## What this PR changes/adds

Introduces a HTTP Authorization header property to allow the authorization header to be set for messages towards the connector under test.

This is done via a static registration of an OKHTTP3 interceptor, since this value is not updated/extended during the lifecycly of the TCK.
