### PR TITLE
feat: Add TestSequenceDiagram annotation

### DIFF
--- a/core/src/main/java/org/eclipse/dataspacetck/core/api/system/TestSequenceDiagram.java
+++ b/core/src/main/java/org/eclipse/dataspacetck/core/api/system/TestSequenceDiagram.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *  Copyright (c) 2023 TNO
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at
@@ -8,7 +8,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *       TNO - initial annotation implementation
  *
  *
  */

--- a/core/src/main/java/org/eclipse/dataspacetck/core/api/system/TestSequenceDiagram.java
+++ b/core/src/main/java/org/eclipse/dataspacetck/core/api/system/TestSequenceDiagram.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ *
+ *
+ */
+
+package org.eclipse.dataspacetck.core.api.system;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+/**
+ * Denotes the sequence diagram of a test.
+ * <p>
+ * The Mermaid sequence diagram notation should be used to allow automated generation of documentation for tests.
+ */
+@Inherited
+@Retention(SOURCE)
+@Target(METHOD)
+@Test
+public @interface TestSequenceDiagram {
+    /**
+     * MermaidJS Sequence diagram string, without "sequenceDiagram".
+     */
+    String value();
+}

--- a/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationConsumer01Test.java
+++ b/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationConsumer01Test.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspacetck.dsp.verification.cn;
 
 import org.eclipse.dataspacetck.core.api.system.MandatoryTest;
+import org.eclipse.dataspacetck.core.api.system.TestSequenceDiagram;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 
@@ -30,6 +31,30 @@ public class ContractNegotiationConsumer01Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN_C:01-01: Verify contract request, offer received, consumer accepted, provider agreed, consumer verified, provider finalized")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (provider)
+            participant CUT as Connector Under Test (consumer)
+
+            TCK->>CUT: Signal to start negotiation
+
+            CUT->>TCK: ContractRequestMessage
+            TCK-->>CUT: ContractNegotiation
+            
+            TCK->>CUT: ContractOfferMessage
+            CUT-->>TCK: 200 OK
+            
+            CUT->>TCK: ContractNegotiationEventMessage:accepted
+            TCK-->>CUT: 200 OK
+            
+            TCK->>CUT: ContractAgreementMessage
+            CUT-->>TCK: 200 OK
+            
+            CUT->>TCK: ContractAgreementVerificationMessage
+            TCK-->>CUT: 200 OK
+            
+            TCK->>CUT: ContractNegotiationEventMessage:finalized
+            CUT-->>TCK: 200 OK
+            """)
     public void cn_c_01_01() {
         negotiationMock.recordInitializedAction(ConsumerActions::postRequest);
         negotiationMock.recordOfferedAction(ConsumerActions::postAccepted);

--- a/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider01Test.java
+++ b/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider01Test.java
@@ -16,6 +16,8 @@
 package org.eclipse.dataspacetck.dsp.verification.cn;
 
 import org.eclipse.dataspacetck.core.api.system.MandatoryTest;
+import org.eclipse.dataspacetck.core.api.system.TestSequenceDiagram;
+import org.eclipse.dataspacetck.dsp.system.api.statemachine.ContractNegotiation;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 
@@ -30,6 +32,19 @@ public class ContractNegotiationProvider01Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN:01-01: Verify contract request, offer received, consumer terminated")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (consumer)
+            participant CUT as Connector Under Test (provider)
+
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            CUT->>TCK: ContractOfferMessage
+            TCK-->>CUT: 200 OK
+            
+            CUT->>TCK: ContractNegotiationTerminationMessage
+            TCK-->>CUT: 200 OK
+            """)
     public void cn_01_01() {
 
         negotiationMock.recordContractRequestedAction(ProviderActions::postOffer);
@@ -47,6 +62,22 @@ public class ContractNegotiationProvider01Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN:01-02: Verify contract request, offer received, consumer counter-offer, provider terminated")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (consumer)
+            participant CUT as Connector Under Test (provider)
+
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            CUT->>TCK: ContractOfferMessage
+            TCK-->>CUT: 200 OK
+            
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            CUT->>TCK: ContractNegotiationTerminationMessage
+            TCK-->>CUT: 200 OK
+            """)
     public void cn_01_02() {
 
         negotiationMock.recordContractRequestedAction(ProviderActions::postOffer);
@@ -66,6 +97,30 @@ public class ContractNegotiationProvider01Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN:01-03: Verify contract request, offer received, consumer accepted, provider agreement, consumer verified, provider finalized")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (consumer)
+            participant CUT as Connector Under Test (provider)
+
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            CUT->>TCK: ContractOfferMessage
+            TCK-->>CUT: 200 OK
+            
+            TCK->>CUT: ContractNegotiationEventMessage:accepted
+            CUT-->>TCK: 200 OK
+            
+            CUT->>TCK: ContractAgreementMessage
+            TCK-->>CUT: 200 OK
+            
+            TCK->>CUT: ContractAgreementVerificationMessage
+            CUT-->>TCK: 200 OK
+            
+            CUT->>TCK: ContractNegotiationEventMessage:finalized
+            
+            CUT->>TCK: ContractNegotiationTerminationMessage
+            TCK-->>CUT: 200 OK
+            """)
     public void cn_01_03() {
 
         negotiationMock.recordContractRequestedAction(ProviderActions::postOffer);
@@ -89,6 +144,24 @@ public class ContractNegotiationProvider01Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN:01-04: Verify contract request, provider agreement, consumer verified, provider finalized")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (consumer)
+            participant CUT as Connector Under Test (provider)
+
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+                        
+            CUT->>TCK: ContractAgreementMessage
+            TCK-->>CUT: 200 OK
+            
+            TCK->>CUT: ContractAgreementVerificationMessage
+            CUT-->>TCK: 200 OK
+            
+            CUT->>TCK: ContractNegotiationEventMessage:finalized
+            
+            CUT->>TCK: ContractNegotiationTerminationMessage
+            TCK-->>CUT: 200 OK
+            """)
     public void cn_01_04() {
 
         negotiationMock.recordContractRequestedAction(ProviderActions::postAgreed);

--- a/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider01Test.java
+++ b/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider01Test.java
@@ -17,7 +17,6 @@ package org.eclipse.dataspacetck.dsp.verification.cn;
 
 import org.eclipse.dataspacetck.core.api.system.MandatoryTest;
 import org.eclipse.dataspacetck.core.api.system.TestSequenceDiagram;
-import org.eclipse.dataspacetck.dsp.system.api.statemachine.ContractNegotiation;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 

--- a/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider02Test.java
+++ b/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider02Test.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspacetck.dsp.verification.cn;
 
 import org.eclipse.dataspacetck.core.api.system.MandatoryTest;
+import org.eclipse.dataspacetck.core.api.system.TestSequenceDiagram;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 
@@ -31,6 +32,16 @@ public class ContractNegotiationProvider02Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN:02-01: Verify contract request, provider terminated")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (consumer)
+            participant CUT as Connector Under Test (provider)
+
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            CUT->>TCK: ContractNegotiationTerminationMessage
+            TCK-->>CUT: 200 OK
+            """)
     public void cn_02_01() {
 
         negotiationMock.recordContractRequestedAction(ProviderActions::postTerminate);
@@ -46,6 +57,16 @@ public class ContractNegotiationProvider02Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN:02-02: Verify contract request, consumer terminated")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (consumer)
+            participant CUT as Connector Under Test (provider)
+
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            TCK->>CUT: ContractNegotiationTerminationMessage
+            CUT-->>TCK: 200 OK
+            """)
     public void cn_02_02() {
 
         negotiationPipeline
@@ -59,6 +80,19 @@ public class ContractNegotiationProvider02Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN:02-03: Verify contract request, provider agreement, consumer terminated")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (consumer)
+            participant CUT as Connector Under Test (provider)
+
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            CUT->>TCK: ContractAgreementMessage
+            TCK-->>CUT: 200 OK
+            
+            TCK->>CUT: ContractNegotiationTerminationMessage
+            CUT-->>TCK: 200 OK
+            """)
     public void cn_02_03() {
 
         negotiationMock.recordContractRequestedAction(ProviderActions::postAgreed);
@@ -76,6 +110,19 @@ public class ContractNegotiationProvider02Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN:02-04: Verify contract request, offer received, consumer terminated")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (consumer)
+            participant CUT as Connector Under Test (provider)
+
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            CUT->>TCK: ContractOfferMessage
+            TCK-->>CUT: 200 OK
+                        
+            TCK->>CUT: ContractNegotiationTerminationMessage
+            CUT-->>TCK: 200 OK
+            """)
     public void cn_02_04() {
 
         negotiationMock.recordContractRequestedAction(ProviderActions::postOffer);
@@ -93,6 +140,19 @@ public class ContractNegotiationProvider02Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN:02-05: Verify contract request, offer received, provider terminated")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (consumer)
+            participant CUT as Connector Under Test (provider)
+
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            CUT->>TCK: ContractOfferMessage
+            TCK-->>CUT: 200 OK
+                        
+            CUT->>TCK: ContractNegotiationTerminationMessage
+            TCK-->>CUT: 200 OK
+            """)
     public void cn_02_05() {
 
         negotiationMock.recordContractRequestedAction(negotiation -> {
@@ -114,6 +174,22 @@ public class ContractNegotiationProvider02Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN:02-06: Verify contract request, offer received, consumer accepted, provider terminated")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (consumer)
+            participant CUT as Connector Under Test (provider)
+
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            CUT->>TCK: ContractOfferMessage
+            TCK-->>CUT: 200 OK
+            
+            TCK->>CUT: ContractNegotiationEventMessage:accepted
+            CUT-->>TCK: 200 OK
+            
+            CUT->>TCK: ContractNegotiationTerminationMessage
+            TCK-->>CUT: 200 OK
+            """)
     public void cn_02_06() {
 
         negotiationMock.recordContractRequestedAction(ProviderActions::postOffer);
@@ -133,6 +209,22 @@ public class ContractNegotiationProvider02Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN:02-07: Verify contract request, provider agreement, consumer verified, provider terminated")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (consumer)
+            participant CUT as Connector Under Test (provider)
+
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            CUT->>TCK: ContractAgreementMessage
+            TCK-->>CUT: 200 OK
+            
+            TCK->>CUT: ContractVerificationMessage
+            CUT-->>TCK: 200 OK
+            
+            CUT->>TCK: ContractNegotiationTerminationMessage
+            TCK-->>CUT: 200 OK
+            """)
     public void cn_02_07() {
 
         negotiationMock.recordContractRequestedAction(ProviderActions::postAgreed);

--- a/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider03Test.java
+++ b/dsp/dsp-contract-negotiation/src/main/java/org/eclipse/dataspacetck/dsp/verification/cn/ContractNegotiationProvider03Test.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspacetck.dsp.verification.cn;
 
 import org.eclipse.dataspacetck.core.api.system.MandatoryTest;
+import org.eclipse.dataspacetck.core.api.system.TestSequenceDiagram;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 
@@ -28,6 +29,25 @@ public class ContractNegotiationProvider03Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN:03-01: Verify contract request, provider agreement, consumer verified, provider finalized, invalid consumer terminated")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (consumer)
+            participant CUT as Connector Under Test (provider)
+
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            CUT->>TCK: ContractAgreementMessage
+            TCK-->>CUT: 200 OK
+            
+            TCK->>CUT: ContractVerificationMessage
+            CUT-->>TCK: 200 OK
+            
+            CUT->>TCK: ContractNegotiationEventMessage:finalized
+            TCk-->>CUT: 200 OK
+            
+            TCK->>CUT: ContractNegotiationTerminationMessage
+            CUT-->>TCK: 4xx ERROR
+            """)
     public void cn_03_01() {
 
         // Sends an invalid terminate message that should result in an error
@@ -49,6 +69,19 @@ public class ContractNegotiationProvider03Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN:03-02: Verify contract request, offer received, invalid consumer verified")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (consumer)
+            participant CUT as Connector Under Test (provider)
+
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            CUT->>TCK: ContractOfferMessage
+            TCK-->>CUT: 200 OK
+            
+            TCk->>CUT: ContractVerificationMessage
+            CUT-->>TCK: 4xx ERROR
+            """)
     public void cn_03_02() {
 
         // Sends an invalid consumer verified that should result in an error
@@ -66,6 +99,22 @@ public class ContractNegotiationProvider03Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN:03-03: Verify contract request, offer received, consumer accepted, illegal consumer verified")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (consumer)
+            participant CUT as Connector Under Test (provider)
+
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            CUT->>TCK: ContractOfferMessage
+            TCK-->>CUT: 200 OK
+            
+            TCK->>CUT: ContractNegotiationEventMessage:accepted
+            CUT-->>TCK: 200 OK
+            
+            TCk->>CUT: ContractVerificationMessage
+            CUT-->>TCK: 4xx ERROR
+            """)
     public void cn_03_03() {
 
         negotiationMock.recordContractRequestedAction(ProviderActions::postOffer);
@@ -83,6 +132,22 @@ public class ContractNegotiationProvider03Test extends AbstractContractNegotiati
 
     @MandatoryTest
     @DisplayName("CN:03-04: Verify contract request, offer received, consumer counter-offer (x2), provider terminated")
+    @TestSequenceDiagram("""
+            participant TCK as Technology Compatibility Kit (consumer)
+            participant CUT as Connector Under Test (provider)
+
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            CUT->>TCK: ContractOfferMessage
+            TCK-->>CUT: 200 OK
+            
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: ContractNegotiation
+            
+            TCK->>CUT: ContractRequestMessage
+            CUT-->>TCK: 4xx ERROR
+            """)
     public void cn_03_04() {
 
         negotiationMock.recordContractRequestedAction(ProviderActions::postOffer);


### PR DESCRIPTION
## What this PR changes/adds

This PR adds the `TestSequenceDiagram` annotation, that allows to input a string that contains a sequence diagram in the form of [MermaidJS](https://mermaid.js.org/syntax/sequenceDiagram.html).

In the examples around the tests, I've omitted the `sequenceDiagram` part, since that can be added to all strings when parsing these with an annotation processor.

These sequence diagrams can be injected into documentation via an annotation processor to provide a clear overview of all tests and the expected flows from the TCK and CUT. Also for CUT developers having the sequence diagrams inline with the tests will help in debugging issues.
